### PR TITLE
Send Payjoin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -50,7 +50,7 @@ android {
 
     defaultConfig {
         applicationId 'com.bullbitcoin.mobile'
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()

--- a/lib/send/bloc/send_cubit.dart
+++ b/lib/send/bloc/send_cubit.dart
@@ -21,6 +21,9 @@ import 'package:bb_mobile/wallet/bloc/wallet_bloc.dart';
 import 'package:boltz_dart/boltz_dart.dart' as boltz;
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:http/http.dart' as http;
+import 'package:payjoin_flutter/send.dart';
+import 'package:payjoin_flutter/uri.dart' as pj_uri;
 
 class SendCubit extends Cubit<SendState> {
   SendCubit({
@@ -1122,6 +1125,74 @@ class SendCubit extends Cubit<SendState> {
       if (!isLn) {
         final fees = _networkFeesCubit.state.selectedOrFirst(false);
         baseLayerBuild(networkFees: fees);
+        if (state.payjoinEndpoint != null) {
+          final ohttpProxyUrl =
+              await pj_uri.Url.fromStr('https://ohttp.achow101.com');
+          final payjoinDirectory = pj_uri.Url.fromStr('https://payjo.in');
+
+          // Initiate Payjoin request
+          final initialPsbt = state.psbt; // Assume this is your initial PSBT
+
+          final maybePjUri =
+              await pj_uri.Uri.fromStr(state.payjoinEndpoint!.toString());
+          final pjUri = maybePjUri.checkPjSupported();
+          final senderBuilder = await SenderBuilder.fromPsbtAndUri(
+            psbtBase64: initialPsbt,
+            pjUri: pjUri,
+          );
+
+          // TODO get appropriateminFeeRate from `fees`
+          final minFeeRate = BigInt.from(250);
+          final sender = await senderBuilder.buildRecommended(
+            minFeeRate: minFeeRate,
+          );
+          final (postReq, postReqCtx) =
+              await sender.extractV2(ohttpProxyUrl: ohttpProxyUrl);
+
+          // TODO handle if null
+          final postRes = await http.post(
+            Uri.parse(postReq.url.asString()),
+            headers: {
+              'Content-Type': postReq.contentType,
+            },
+            body: postReq.body,
+          );
+          final getCtx =
+              await postReqCtx.processResponse(response: postRes.bodyBytes);
+          String? proposal;
+          while (true) {
+            try {
+              final (getRequest, getReqCtx) = await getCtx.extractReq(
+                ohttpRelay: ohttpProxyUrl,
+              );
+              final getRes = await http.post(
+                Uri.parse(getRequest.url.asString()),
+                headers: {
+                  'Content-Type': getRequest.contentType,
+                },
+                body: getRequest.body,
+              );
+              proposal = await getCtx.processResponse(
+                response: getRes.bodyBytes,
+                ohttpCtx: getReqCtx,
+              );
+              if (proposal != null) {
+                break;
+              }
+            } catch (e) {
+              // If the session times out or another error occurs, rethrow the error
+              return;
+            }
+          }
+          final payjoin =
+              await _walletTx.signPsbt(psbt: proposal, wallet: wallet);
+          emit(
+            state.copyWith(
+              psbtSigned: payjoin.$2?.toString(),
+              tx: payjoin.$1?.$1,
+            ),
+          );
+        }
         return;
       }
       // context.read<WalletBloc>().state.wallet;

--- a/lib/settings/bitcoin_settings_page.dart
+++ b/lib/settings/bitcoin_settings_page.dart
@@ -51,8 +51,8 @@ class _Screen extends StatelessWidget {
             padding: EdgeInsets.all(24.0),
             child: Column(
               children: [
-                // Gap(8),
-                // TestNetButton(),
+                Gap(8),
+                TestNetButton(),
                 Gap(8),
                 DefaultRBFToggle(),
                 Gap(8),


### PR DESCRIPTION
This is an outline of in-memory payjoin sending

No testing done yet.

Transaction details are missing, but I reckon this is close to what a sending flow looks like written straight into `processSendButton` without abstraction. I need to figure out a way to test this, probably by syncing a testnet 3 full node or finding a mutinynet electrum server somewhere.